### PR TITLE
Revert "Fix people flow diagram on burnout page"

### DIFF
--- a/guides/handling-burnout-and-career-planning.md
+++ b/guides/handling-burnout-and-career-planning.md
@@ -30,7 +30,7 @@ Maintainer activities, of course, aim to keep a project going; we want to avoid 
 
 Consider this diagram of how people flow through a project:
 
-![People Flow diagram](assets/people-flow.jpg)
+<figure><img src="../.gitbook/assets/People Flow (2).png" alt=""><figcaption></figcaption></figure>
 
 You can encourage healthy movement with steps such as:
 


### PR DESCRIPTION
Reverts Open-Source-Collective/docs#11. 

Current one should've been kept. Was trying to figure out how to preview PRs. 